### PR TITLE
Remove the alpha let the root flag decide what to get

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "aura/payload-interface": "~3.0.0@alpha"
+        "aura/payload-interface": "~3.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,5 +28,6 @@
         "psr-4": {
             "Aura\\Payload\\": "tests/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Hi Paul, 

I hope this PR will help to resolve the issue on further releases and there by the root flag of the composer.json of the project can decide the minimum stability. 

This further needs testing, so you could tag an alpha and see how things work.
