### PR TITLE
Shouldn't we be using a Factory and not a single Payload?

### DIFF
--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Aura\Payload;
+
+class PayloadFactory
+{
+
+    /**
+     * Create a new Payload
+     *
+     * @return Aura\Payload_Interface\PayloadInterface
+     *
+     * @access public
+     */
+    public function newInstance()
+    {
+        return new Payload();
+    }
+}

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Aura\Payload;
+
+class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $payloadFactory = new PayloadFactory();
+
+        $payload = $payloadFactory->newInstance();
+
+        $this->assertInstanceOf('Aura\Payload\Payload', $payload);
+    }
+}


### PR DESCRIPTION
It seems to me that each call to the service should return it's _own_ **new**
payload, and not simply work with a _shared_ instance. If this is correct, I'd
think the injection of a factory would be more appropriate. In this case, I
think the package should provide one and the documentation should suggest it so
as to influence good practice.

It is my understanding that the Payload is considered to be a data transfer
object for the Domain. The implementation outlined in the documentation seems, to
me, unnecessarily influenced by the paradigm suggested by ADR. Specifically, it
seems to suggest that the service object will only receive a single call, eg. a
route dispatching an action calling a single method on the domain.

This implementation seems to imply that for a consuming UI to make multiple
calls to the service, it must instantiate new instances for each call. Perhaps I
am misunderstanding something though.
### Minimal Example:

``` php
class SomeService
{
    protected $payload;

    public function __construct(Payload $payload)
    {
        $this->payload = $payload;
    }

    public function __invoke($foo)
    {
        if ($this->doSomething($foo)) {
            return $this->payload
                ->setStatus(Payload::VALID)
                ->setExtras(['foo' => 'foo does something extra']);
        }

        return $this->payload->setStatus(Payload::VALID);
    }
}

class SomeUI
{
    protected $service;

    public function __construct(SomeService $service)
    {
        $this->service = $service;
    }

    public function __invoke($array)
    {
        foreach ($array as $foo) {
            $payload = $this->service->__invoke($foo);

            // If SomeService::doSomething is true once,
            // all subsequent payloads have "extras"
            if ($extras = $payload->getExtras()) {
                $this->doSomethingExtra($extras);
            }
        }
    }
}
```

Certainly, one could be sure to "clear the state" of the payload every time, or
make sure that all setters are always called if they are pertinent, but this
seems onerous and incorrect.

Also, it is certainly true that the implementing code can trivially implement
their own factory. However, it seems that suggesting this may be better, as it
seems more correct/functional to me.

Let me know if I'm wrong.
Thanks!
