### PR TITLE
Add Abstract Payload

### DIFF
--- a/src/AbstractPayload.php
+++ b/src/AbstractPayload.php
@@ -1,0 +1,69 @@
+<?php
+namespace Aura\Payload;
+
+use Aura\Payload_Interface\PayloadInterface;
+
+abstract class AbstractPayload implements PayloadInterface
+{
+
+    protected $status;
+    protected $input;
+    protected $output;
+    protected $messages;
+    protected $extras;
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setInput($input)
+    {
+        $this->input = $input;
+        return $this;
+    }
+
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    public function setOutput($output)
+    {
+        $this->output = $output;
+        return $this;
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    public function setMessages($messages)
+    {
+        $this->messages = $messages;
+        return $this;
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    public function setExtras($extras)
+    {
+        $this->extras = $extras;
+        return $this;
+    }
+
+    public function getExtras()
+    {
+        return $this->extras;
+    }
+}

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -3,7 +3,7 @@ namespace Aura\Payload;
 
 use Aura\Payload_Interface\PayloadInterface;
 
-class Payload implements PayloadInterface
+class Payload extends AbstractPayload
 {
     const ACCEPTED = 'ACCEPTED';
     const AUTHENTICATED = 'AUTHENTICATED';
@@ -26,64 +26,4 @@ class Payload implements PayloadInterface
     const UPDATED = 'UPDATED';
     const VALID = 'VALID';
 
-    protected $status;
-    protected $input;
-    protected $output;
-    protected $messages;
-    protected $extras;
-
-    public function setStatus($status)
-    {
-        $this->status = $status;
-        return $this;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    public function setInput($input)
-    {
-        $this->input = $input;
-        return $this;
-    }
-
-    public function getInput()
-    {
-        return $this->input;
-    }
-
-    public function setOutput($output)
-    {
-        $this->output = $output;
-        return $this;
-    }
-
-    public function getOutput()
-    {
-        return $this->output;
-    }
-
-    public function setMessages($messages)
-    {
-        $this->messages = $messages;
-        return $this;
-    }
-
-    public function getMessages()
-    {
-        return $this->messages;
-    }
-
-    public function setExtras($extras)
-    {
-        $this->extras = $extras;
-        return $this;
-    }
-
-    public function getExtras()
-    {
-        return $this->extras;
-    }
 }


### PR DESCRIPTION
**Allows extending abstract implementation without forcing Status constants**

Coming off our conversations at:
- auraphp/Aura.Payload_Interface#2
- auraphp/Aura.Payload_Interface#3

I think it makes sense to provide an `Abstract` implementation which allows us
to extends the basic functionality (setters and getters as defined in the
interface), but does not _force_ the use of statuses which we may or may not
want to implement for any given domain.

As it stands, we can _override_ the Status constants (as they are not in the
interface), but I do not believe we can **remove** them short of starting afresh.

This PR would allow us to extend the `AbstractPayload` and _not_ get all the
Status constants, or continue to extends the `Payload` and still get all the
predefined statuses.

I think this might be a proper step in the direction of what I think we want
here, namely: Providing an essentially abstract base class to be extended and
implemented as per the requirements of a domain, while not forcing an onerous
amount of work on the implementor to "just get it up and running".

I'm not sure how this plays with your concern raised in the previously mentioned
thread in regards to type hinting against an Abstract payload. I think the
response, is just "don't do that", no? Why type hint against the Abstract class
when there's a perfectly good interface to type hint against?

Thoughts?
